### PR TITLE
 Ajout des fixtures : tags, jeux vidéo et reviews associées

### DIFF
--- a/src/Doctrine/DataFixtures/TagFixtures.php
+++ b/src/Doctrine/DataFixtures/TagFixtures.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Doctrine\DataFixtures;
+
+use App\Model\Entity\Tag;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+
+final class TagFixtures extends Fixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        // Liste de tags réalistes, sans logique purement incrémentale
+        $tagNames = [
+            'Action',
+            'Aventure',
+            'RPG',
+            'Stratégie',
+            'Simulation',
+            'Horreur',
+            'Puzzle',
+            'Course',
+            'Combat',
+            'Plateforme',
+            'Multijoueur',
+            'Coopératif',
+            'Solo',
+            'FPS',
+            'TPS',
+            'Rétro',
+            'Indépendant',
+            'Sandbox',
+            'Narratif',
+            'Open World',
+            'Pixel Art',
+            'Roguelike',
+            'Survie',
+            'Construction',
+            'Musique'
+        ];
+
+        foreach ($tagNames as $name) {
+            $tag = (new Tag())->setName($name);
+            // Le champ "code" sera généré automatiquement grâce à #[Slug(fields: ['name'])]
+            $manager->persist($tag);
+        }
+
+        $manager->flush();
+    }
+}

--- a/src/Doctrine/DataFixtures/VideoGameFixtures.php
+++ b/src/Doctrine/DataFixtures/VideoGameFixtures.php
@@ -2,8 +2,10 @@
 
 namespace App\Doctrine\DataFixtures;
 
+use App\Model\Entity\Tag;
 use App\Model\Entity\User;
 use App\Model\Entity\VideoGame;
+use App\Model\Entity\Review;
 use App\Rating\CalculateAverageRating;
 use App\Rating\CountRatingsPerValue;
 use DateTimeImmutable;
@@ -11,8 +13,6 @@ use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Faker\Generator;
-
-use function array_fill_callback;
 
 final class VideoGameFixtures extends Fixture implements DependentFixtureInterface
 {
@@ -25,30 +25,56 @@ final class VideoGameFixtures extends Fixture implements DependentFixtureInterfa
 
     public function load(ObjectManager $manager): void
     {
+        // Récupération des utilisateurs et des tags existants
         $users = $manager->getRepository(User::class)->findAll();
+        $allTags = $manager->getRepository(Tag::class)->findAll();
 
-        $videoGames = array_fill_callback(0, 50, fn (int $index): VideoGame => (new VideoGame)
-            ->setTitle(sprintf('Jeu vidéo %d', $index))
-            ->setDescription($this->faker->paragraphs(10, true))
-            ->setReleaseDate(new DateTimeImmutable())
-            ->setTest($this->faker->paragraphs(6, true))
-            ->setRating(($index % 5) + 1)
-            ->setImageName(sprintf('video_game_%d.png', $index))
-            ->setImageSize(2_098_872)
-        );
+        $videoGames = [];
 
-        // TODO : Ajouter les tags aux vidéos
+        // Création de 50 jeux vidéo
+        for ($i = 0; $i < 50; $i++) {
+            $game = (new VideoGame())
+                ->setTitle(sprintf('Jeu vidéo %d', $i))
+                ->setDescription($this->faker->paragraphs(10, true))
+                ->setReleaseDate(new DateTimeImmutable())
+                ->setTest($this->faker->paragraphs(6, true))
+                ->setRating(($i % 5) + 1)
+                ->setImageName(sprintf('video_game_%d.png', $i))
+                ->setImageSize(2_098_872);
 
-        array_walk($videoGames, [$manager, 'persist']);
+            // Associer 1 à 3 tags aléatoires
+            $randomTags = $this->faker->randomElements($allTags, random_int(1, 3));
+            foreach ($randomTags as $tag) {
+                $game->addTag($tag);
+            }
+
+            $videoGames[] = $game;
+            $manager->persist($game);
+        }
+
+        // Création des reviews pour chaque jeu
+        foreach ($videoGames as $game) {
+            $reviewCount = random_int(2, 5);
+
+            for ($j = 0; $j < $reviewCount; $j++) {
+                $review = (new Review())
+                    ->setRating(random_int(1, 5))
+                    ->setComment($this->faker->optional(0.6)->sentence(10))
+                    ->setUser($this->faker->randomElement($users))
+                    ->setVideoGame($game);
+
+                $manager->persist($review);
+            }
+        }
 
         $manager->flush();
-
-        // TODO : Ajouter des reviews aux vidéos
-
     }
 
     public function getDependencies(): array
     {
-        return [UserFixtures::class];
+        return [
+            UserFixtures::class,
+            TagFixtures::class,
+        ];
     }
 }

--- a/src/Model/Entity/VideoGame.php
+++ b/src/Model/Entity/VideoGame.php
@@ -222,6 +222,16 @@ class VideoGame
     {
         return $this->tags;
     }
+    
+    public function addTag(Tag $tag): self
+    {
+    if (!$this->tags->contains($tag)) {
+        $this->tags->add($tag);
+    }
+
+    return $this;
+    }
+
 
     /**
      * @return Collection<Review>


### PR DESCRIPTION
### Objectifs : Implémentation des fixtures nécessaires pour tester les fonctionnalités suivantes :
- Création de tags
- Ajout de jeux vidéo avec 1 à 3 tags
- Génération de reviews avec notes et commentaires
### Fichiers ajoutés
- `TagFixtures.php`
- `VideoGameFixtures.php`